### PR TITLE
0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v0.0.18
+
+### Features
+
+- Keyword search is workspace specific now
+- Better object params support: specifying a key of `properties` will infer that the param is an object (see example below)
+- A route can have `sticky: true` added to it so that it cannot be filtered with keyword search
+- `Documentation` tab is hidden if there is no documentation specified
+- Environment variables previously needed to be saved through click of a button, we've removed the button in favor of using the Enter key
+
+#### New Object Support
+
+```javascript
+{
+  name: "Create User",
+  path: "/v1/users",
+  method: Method.POST,
+  body: [
+    {
+      name: "user",
+      label: "User",
+      properties: [
+        { name: "first_name", required: true },
+        { name: "last_name", required: true },
+        { name: "email", required: true },
+        { name: "dob", type: "date" },
+      ],
+    },
+  ]
+}
+```
+
+### Breaking Changes
+
+- Context no longer has support for `setRouteFilter` and `routeFilter` since it's now namespaced to a workspace. Please use `setWorkspaceSearchKeywords(keywords)` and `getWorkspaceSearchKeywords()` instead
+
+### Notes
+
+- We are going to deprecate `json` as a param option in a future version in favor of a param that has `properties`. We will probably need to do something to have stronger array support so we will leave `json` for now
+
 ## v0.0.17
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badmagic",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Swagger UI alternative written in React",
   "scripts": {
     "build": "npm run clean && npm run copy-css && tsc -p ./",

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -12,18 +12,21 @@ export default React.createContext({
   environment: null,
   darkMode: null,
   setDarkMode: (darkMode: boolean) => {},
-  routeFilter: null,
-  setRouteFilter: (keywords: string) => {},
   setEnvVar: (payload: { key: string; value: any }) => {},
   deleteEnvVar: (payload: { key: string }) => {},
   routeConfig: {},
-  getParam: (filters: { route: Route; param: Param; paramType: ParamType }) =>
-    "",
+  getParam: (filters: {
+    route: Route;
+    param: Param;
+    paramType: ParamType;
+    parent?: string;
+  }) => "",
   setParam: (payload: {
     route: Route;
     param: Param;
     value: any;
     paramType: ParamType;
+    parent?: string;
   }) => {},
   setHeader: (payload: { route: Route; key: string; value: string }) => {},
   setApiResponse: (payload: {
@@ -32,4 +35,6 @@ export default React.createContext({
     error: any;
     loading: boolean;
   }) => {},
+  getWorkspaceSearchKeywords: () => "",
+  setWorkspaceSearchKeywords: (keywords: string) => {},
 });

--- a/src/Environment.tsx
+++ b/src/Environment.tsx
@@ -18,6 +18,13 @@ export default function Environment() {
   const [collapsed, setCollapsed] = useState(true);
   const [newVarName, setNewVarName] = useState("");
 
+  const checkIfSubmitted = (e) => {
+    if (e && e.key === "Enter") {
+      setEnvVar({ key: newVarName, value: "" });
+      setNewVarName("");
+    }
+  };
+
   return (
     <>
       <button
@@ -107,16 +114,9 @@ export default function Environment() {
                 className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-2 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
                 value={newVarName}
                 onChange={(e) => setNewVarName(e.currentTarget.value)}
+                onKeyDown={(e) => checkIfSubmitted(e)}
+                placeholder="Specify env var name and press Enter to continue"
               />
-              <Button
-                className="ml-2"
-                onClick={() => {
-                  setEnvVar({ key: newVarName, value: "" });
-                  setNewVarName("");
-                }}
-              >
-                Create
-              </Button>
             </div>
             <div className="flex mt-2 pt-2 border-t">
               <Button

--- a/src/Route.tsx
+++ b/src/Route.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
-import { get } from "lodash-es";
+import { get, compact } from "lodash-es";
 import useAxios from "@smartrent/use-axios";
 import axios from "axios";
 
@@ -17,7 +17,7 @@ export default function Route({ route }: { route: Route }) {
     Context
   );
   const [collapsed, setCollapsed] = useState(true);
-  const [activeTab, setActiveTab] = useState('request');
+  const [activeTab, setActiveTab] = useState("request");
 
   const routeConfigVars = get(routeConfig, route.name, {
     headers: {},
@@ -58,25 +58,25 @@ export default function Route({ route }: { route: Route }) {
     route.plugins && route.plugins.length ? route.plugins : workspace.plugins;
 
   // Tabs for the navigation component for each route
-  const tabs = [
+  const tabs = compact([
     {
       key: "request",
       label: "Try Request",
-      enabled: true,
     },
-    {
-      key: "docs",
-      label: "Documentation",
-      enabled: !!route.documentation,
-    }
-  ]
+    route.documentation
+      ? {
+          key: "docs",
+          label: "Documentation",
+        }
+      : null,
+  ]);
 
   const renderBody = (activeTab: string) => {
     let content;
 
     switch (activeTab) {
       case "request":
-        content = 
+        content = (
           <>
             <Request
               route={route}
@@ -91,35 +91,36 @@ export default function Route({ route }: { route: Route }) {
               plugins={plugins}
             />
           </>
+        );
         break;
-      case "docs": 
-        content = <Docs documentation={route.documentation} darkMode={darkMode}/>;
+      case "docs":
+        content = (
+          <Docs documentation={route.documentation} darkMode={darkMode} />
+        );
         break;
       default:
         content = <p className="italic p-2">Something went wrong...</p>;
     }
 
     return content;
-  }
+  };
 
   return (
     <div
-      className={
-        darkMode
-          ? "bg-gray-900 border border-gray-700 rounded overflow-x-hidden my-2"
-          : "bg-white border border-gray-300 rounded overflow-x-hidden my-2"
-      }
+      style={route.sticky ? { borderRight: "1px solid rgb(251, 189, 28)" } : {}}
+      className={`border rounded overflow-x-hidden my-2 ${
+        darkMode ? "bg-gray-900 border-gray-700" : "bg-white border-gray-300"
+      }`}
     >
       <div
         className="flex justify-start items-center overflow-hidden p-2"
         onClick={() => setCollapsed(!collapsed)}
+        style={{ cursor: "pointer" }}
       >
         <div
-          className={
-            darkMode
-              ? "w-16 flex flex-shrink-0 items-center justify-center text-xs text-gray-700 font-semibold p-1 mr-2 border border-gray-700 rounded"
-              : "w-16 flex flex-shrink-0 items-center justify-center text-xs text-gray-700 font-semibold p-1 mr-2 border border-gray-300 rounded"
-          }
+          className={`w-16 flex flex-shrink-0 items-center justify-center text-xs text-gray-700 font-semibold p-1 mr-2 border rounded ${
+            darkMode ? "border-gray-700" : "border-gray-300"
+          }`}
           style={{
             backgroundColor: get(Helpers.colors.routes, method),
           }}
@@ -128,11 +129,9 @@ export default function Route({ route }: { route: Route }) {
         </div>
 
         <div
-          className={
-            darkMode
-              ? "flex flex-grow-2 text-gray-100 mr-auto"
-              : "flex flex-grow-2 text-gray-800 mr-auto"
-          }
+          className={`flex flex-grow-2 mr-auto ${
+            darkMode ? "text-gray-100" : "text-gray-800"
+          }`}
         >
           {Helpers.buildUrl({
             route,
@@ -142,20 +141,29 @@ export default function Route({ route }: { route: Route }) {
           })}
         </div>
         <div
-          className={
-            darkMode
-              ? "flex text-right text-gray-100 ml-2 mr-1"
-              : "flex text-right text-gray-800 ml-2 mr-1"
-          }
+          className={`flex text-right ml-2 mr-1 items-center ${
+            darkMode ? "text-gray-100" : "text-gray-800"
+          }`}
         >
           {route.name}
+          {route.sticky ? (
+            <span className="text-xs ml-1" title="Sticky">
+              ⭐
+            </span>
+          ) : (
+            ""
+          )}
         </div>
       </div>
-      <div className={collapsed ? "none" : "w-full p-2"}>
-        {!collapsed && (
-          <Navigation tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
-        )}
-      </div>
+      {!collapsed && tabs && tabs.length > 1 && (
+        <div className={collapsed ? "none" : "w-full p-2"}>
+          <Navigation
+            tabs={tabs}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+          />
+        </div>
+      )}
       <div className={collapsed ? "none" : "flex p-2"}>
         {!collapsed && renderBody(activeTab)}
       </div>

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -7,21 +7,26 @@ import Route from "./Route";
 import { Route as RouteProps } from "./types";
 
 export default function Workspace() {
-  const { workspace, routeFilter } = useContext(Context);
+  const { workspace, getWorkspaceSearchKeywords } = useContext(Context);
   if (!workspace) {
     return <div>Select a workspace to get started.</div>;
   }
 
   const allRoutes = workspace && workspace.routes ? workspace.routes : [];
-  const filteredRoutes = filter(allRoutes, ({ name, path }: RouteProps) => {
-    if (!routeFilter) {
-      return true;
+  const filteredRoutes = filter(
+    allRoutes,
+    ({ name, path, sticky }: RouteProps) => {
+      const keywords: string = getWorkspaceSearchKeywords();
+      if (!keywords) {
+        return true;
+      }
+      return (
+        name.toLowerCase().includes(keywords.toLowerCase()) ||
+        path.toLowerCase().includes(keywords.toLowerCase()) ||
+        sticky
+      );
     }
-    return (
-      name.toLowerCase().includes(routeFilter.toLowerCase()) ||
-      path.toLowerCase().includes(routeFilter.toLowerCase())
-    );
-  });
+  );
 
   return (
     <div className="p-4 mt-12">

--- a/src/Workspaces.tsx
+++ b/src/Workspaces.tsx
@@ -13,9 +13,12 @@ export default function Workspaces() {
     setWorkspaceName,
     workspace,
     darkMode,
-    setRouteFilter,
-    routeFilter,
+    getWorkspaceSearchKeywords,
+    setWorkspaceSearchKeywords,
   } = useContext(Context);
+
+  const keywords = getWorkspaceSearchKeywords();
+
   return (
     <div
       className={
@@ -47,14 +50,19 @@ export default function Workspaces() {
               ))}
             </Select>
           </div>
-          <div className="ml-2">
-            <TextInput
-              type="text"
-              placeholder="Search Routes"
-              value={routeFilter}
-              onChange={(e) => setRouteFilter(e.currentTarget.value)}
-            />
-          </div>
+          {workspace && workspace.name && (
+            <div className="ml-2">
+              <TextInput
+                type="text"
+                placeholder="Search Routes"
+                value={keywords}
+                onChange={(e) =>
+                  setWorkspaceSearchKeywords(e.currentTarget.value)
+                }
+              />
+            </div>
+          )}
+
           <div className="flex items-center ml-2">
             <Environment />
           </div>

--- a/src/common/Input.tsx
+++ b/src/common/Input.tsx
@@ -15,22 +15,25 @@ export default function Input({
   reFetch,
   route,
   paramType,
+  parent,
 }: {
   param: Param;
   route: Route;
   reFetch: () => void;
   paramType: ParamType;
+  parent?: string;
 }) {
   const { setParam, getParam } = useContext(Context);
 
   const label = param.label ? param.label : startCase(param.name);
 
-  const value = getParam({ route, param, paramType });
+  const value = getParam({ route, param, paramType, parent });
 
-  const onChange = (value: any) => setParam({ route, param, value, paramType });
+  const onChange = (value: any) =>
+    setParam({ route, param, value, paramType, parent });
 
   useEffect(() => {
-    setParam({ route, param, value, paramType });
+    setParam({ route, param, value, paramType, parent });
   }, []);
 
   const onKeyDown = (e: any) => {

--- a/src/common/Label.tsx
+++ b/src/common/Label.tsx
@@ -7,15 +7,17 @@ type Props = {
   children: any;
   onClick?: () => void;
   style?: Object;
+  size?: "xs" | "sm" | "lg" | "xl";
 };
 
-export default function Label({ children, onClick, style }: Props) {
+export default function Label({ children, onClick, style, size }: Props) {
   const { darkMode } = useContext(Context);
 
   return (
     <div
       onClick={onClick}
-      className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-1"
+      className={`block uppercase tracking-wide text-gray-700 text-${size ||
+        "xs"} font-bold mb-1`}
       style={{ ...Helpers.getStyles(darkMode, "label"), ...(style || {}) }}
     >
       {children}

--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -38,9 +38,9 @@ export default {
 
   getDefaultWorkspace(): Workspace {
     return {
-      id: "default",
+      id: "",
       routes: [],
-      name: "default",
+      name: "",
       plugins: [],
       config: {
         baseUrl: "",
@@ -227,9 +227,7 @@ export default {
               borderLeft: "1px solid #eee",
             };
       case "label":
-        return darkMode
-          ? { color: "rgb(206, 206, 206)", fontSize: "13px" }
-          : { color: "#555", fontSize: "13px" };
+        return darkMode ? { color: "rgb(206, 206, 206)" } : { color: "#555" };
       default:
         return {};
     }

--- a/src/route/Navigation.tsx
+++ b/src/route/Navigation.tsx
@@ -5,7 +5,6 @@ import Helpers from "../lib/helpers";
 type Tab = {
   key: string;
   label: string;
-  enabled: boolean;
 };
 
 type Props = {
@@ -28,15 +27,11 @@ export default ({ tabs, activeTab, setActiveTab }: Props) => {
       liClasses = "-mb-px mr-1";
     }
 
-    if (!tab.enabled) {
-      anchorClasses = Helpers.classes.tabs.disabled;
-    }
-
     return (
       <li className={liClasses} key={`navigation_tab_${tab.key}`}>
         <a
           className={anchorClasses}
-          onClick={tab.enabled ? () => setActiveTab(tab.key) : null}
+          onClick={() => setActiveTab(tab.key)}
           href="#"
         >
           {tab.label}

--- a/src/route/Params.tsx
+++ b/src/route/Params.tsx
@@ -2,9 +2,46 @@ import React from "react";
 import { map, assign } from "lodash-es";
 
 import Input from "../common/Input";
+import Label from "../common/Label";
 import Helpers from "../lib/helpers";
 
 import { Route, Param, ParamType } from "../types";
+
+function mapInputs({ inputs, route, paramType, reFetch, parent }) {
+  return map(inputs, (param: Param, idx: number) => {
+    // Object datatype
+    if (param.properties) {
+      return (
+        <div className="mb-2" key={idx}>
+          <Label size="lg">{param.label}</Label>
+          {mapInputs({
+            inputs: param.properties,
+            route,
+            paramType,
+            reFetch,
+            parent: param.name,
+          })}
+        </div>
+      );
+    }
+
+    // Other data types
+    return (
+      <Input
+        key={idx}
+        route={route}
+        param={
+          paramType === ParamType.urlParams
+            ? assign(param, { required: true })
+            : param
+        }
+        reFetch={reFetch}
+        paramType={paramType}
+        parent={parent}
+      />
+    );
+  });
+}
 
 export default function Params({
   route,
@@ -30,21 +67,7 @@ export default function Params({
 
   return (
     <div className="mb-2">
-      {map(inputs, (param: Param, idx) => {
-        return (
-          <Input
-            key={idx}
-            route={route}
-            param={
-              paramType === ParamType.urlParams
-                ? assign(param, { required: true })
-                : param
-            }
-            reFetch={reFetch}
-            paramType={paramType}
-          />
-        );
-      })}
+      {mapInputs({ inputs, route, paramType, reFetch, parent: null })}
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,8 @@ export type Param = {
   placeholder?: string;
   options?: Option[];
   defaultValue?: string;
-  json?: boolean; // value should be stringified
+  json?: boolean; // value should be stringified, deprecated -- use `properties`
+  properties?: Param[]; // if working with json, pass in array of properties
 };
 
 export enum Method {
@@ -36,6 +37,7 @@ export type Route = {
   method?: Method;
   plugins?: Plugin[];
   documentation?: string;
+  sticky?: boolean;
 };
 
 export enum Inject {


### PR DESCRIPTION
- Keyword search is workspace specific now
- Better object params support: specifying a key of  will infer that the param is an object (see example below)
- A route can have  added to it so that it cannot be filtered with keyword search
-  tab is hidden if there is no documentation specified
- Environment variables previously needed to be saved through click of a button, we've removed the button in favor of using the Enter key

See Changelog.md for more information