### PR TITLE
Prevent scroll to top when switching tabs in docs

### DIFF
--- a/src/route/Navigation.tsx
+++ b/src/route/Navigation.tsx
@@ -31,7 +31,10 @@ export default ({ tabs, activeTab, setActiveTab }: Props) => {
       <li className={liClasses} key={`navigation_tab_${tab.key}`}>
         <a
           className={anchorClasses}
-          onClick={() => setActiveTab(tab.key)}
+          onClick={(e) => {
+            e.preventDefault();
+            setActiveTab(tab.key);
+          }}
           href="#"
         >
           {tab.label}


### PR DESCRIPTION
Currently, switching between the Try Request and Documentation tabs causes the browser to scroll to the top of the page. Calling `e.preventDefault()` in the link's onClick handler will prevent this.