### PR TITLE
Null/undefined handling for body params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.0.21
+
+### Features
+
+- Added a button to explicitly set request param values to `null`
+- Added a preview of the request body
+
+### Bugfixes
+
+- Clearing a param value removes it from the request instead of setting the value to `null` ([#26](https://github.com/smartrent/badmagic/issues/26))
+- Headers render with a light font color in dark mode
+
 ## v0.0.20
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badmagic",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Swagger UI alternative written in React",
   "scripts": {
     "build": "npm run clean && npm run copy-css && tsc -p ./",

--- a/src/ContextProvider.tsx
+++ b/src/ContextProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { get, set, omit } from "lodash-es";
+import { get, set, unset, omit } from "lodash-es";
 
 import Context from "./Context";
 
@@ -168,11 +168,12 @@ export default function ContextProvider({
             propertyPath = `[${parent}]${propertyPath}`;
           }
 
-          set(
-            newRouteConfig,
-            `[${route.name}][${paramType}]${propertyPath}`,
-            newValue
-          );
+          const fullParamPath = `[${route.name}][${paramType}]${propertyPath}`;
+          if (typeof value === "undefined") {
+            unset(newRouteConfig, fullParamPath);
+          } else {
+            set(newRouteConfig, fullParamPath, newValue);
+          }
 
           Storage.set({
             key: `${workspace.id}-route-config`,

--- a/src/common/Input.tsx
+++ b/src/common/Input.tsx
@@ -87,7 +87,7 @@ export default function Input({
       <TextInput
         required={param.required}
         type={param.type || "text"}
-        placeholder={param.placeholder || label}
+        placeholder={value === null ? "(null)" : param.placeholder || label}
         onKeyDown={onKeyDown}
         onChange={(e) => onChange(e.currentTarget.value)}
         value={value ? value : ""}
@@ -102,13 +102,23 @@ export default function Input({
       </Label>
       <div className="flex">
         {inputDOM}
-        {value !== undefined && value !== null && (
+        {typeof value !== "undefined" ? (
+          <Button
+            outline
+            className="flex-shrink-0 ml-2"
+            onClick={() =>
+              setParam({ route, param, value: undefined, paramType })
+            }
+          >
+            Clear
+          </Button>
+        ) : (
           <Button
             outline
             className="flex-shrink-0 ml-2"
             onClick={() => setParam({ route, param, value: null, paramType })}
           >
-            Clear
+            Null
           </Button>
         )}
       </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { default as Workspaces } from "./Workspaces";
 export { default as Workspace } from "./Workspace";
 export { default as ContextProvider } from "./ContextProvider";
 export { default as Theme } from "./Theme";
+export { default as BodyPreview } from "./route/BodyPreview";
 export { default as ApiResponse } from "./route/ApiResponse";
 export { default as ApiError } from "./route/ApiError";
 

--- a/src/route/BodyPreview.tsx
+++ b/src/route/BodyPreview.tsx
@@ -1,0 +1,41 @@
+import React, { useContext } from "react";
+import { get, isEmpty } from "lodash-es";
+import ReactJson from "react-json-view";
+
+import Context from "../Context";
+import Helpers from "../lib/helpers";
+import { Route } from "../types";
+
+interface BodyPreviewProps {
+  route: Route;
+}
+
+export default function BodyPreview({ route }: BodyPreviewProps) {
+  const { routeConfig, darkMode } = useContext(Context);
+
+  const { body } = get(routeConfig, route.name, { body: {} });
+
+  if (isEmpty(body)) {
+    return null;
+  }
+
+  return (
+    <div className="mb-4">
+      <div
+        className="flex-shrink-0 inline-flex text-xs font-bold bg-transparent mb-2"
+        style={{
+          ...Helpers.getStyles(darkMode, "label"),
+        }}
+      >
+        Request Body
+      </div>
+      <ReactJson
+        enableClipboard={false}
+        displayObjectSize={false}
+        displayDataTypes={false}
+        src={{ ...body }}
+        theme={darkMode ? "bright" : "rjv-default"}
+      />
+    </div>
+  );
+}

--- a/src/route/Headers.tsx
+++ b/src/route/Headers.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { map } from "lodash-es";
 
 import Label from "../common/Label";
+import Context from "../Context";
 
 export default function Headers({ headers }: { headers: any }) {
+  const { darkMode } = useContext(Context);
   const [collapsed, setCollapsed] = useState(true);
   if (!headers) {
     return null;
@@ -19,6 +21,7 @@ export default function Headers({ headers }: { headers: any }) {
       </div>
       {!collapsed && (
         <div
+          className={darkMode ? "text-gray-100" : "text-gray-800"}
           style={{
             padding: "8px",
             border: "1px solid #eee",

--- a/src/route/Response.tsx
+++ b/src/route/Response.tsx
@@ -4,8 +4,9 @@ import ApiError from "./ApiError";
 import ApiResponse from "./ApiResponse";
 import InjectPlugins from "./InjectPlugins";
 import { Route, Inject, Plugin } from "../types";
+import BodyPreview from "./BodyPreview";
 
-export default function Request({
+export default function Response({
   route,
   reFetch,
   loading,
@@ -25,6 +26,7 @@ export default function Request({
       loading={loading}
       plugins={plugins || []}
     >
+      <BodyPreview route={route} />
       <ApiResponse route={route} />
       <ApiError route={route} />
     </InjectPlugins>


### PR DESCRIPTION
### Changes

1. The "Clear" button now deletes params from the request body instead of setting them to `null`
1. Added a "Null" button to explicitly set the value to `null` when the param value is undefined
1. Added request body preview

Fixes #26