### PR TITLE
Bugfix: setEnvVar

### DIFF
--- a/src/ContextProvider.tsx
+++ b/src/ContextProvider.tsx
@@ -32,8 +32,12 @@ export default function ContextProvider({
     if (!workspace) {
       return;
     }
-    const newEnv = { ...environment };
-    newEnv[key] = value;
+
+    // We need to fetch synchronously from localStorage here otherwise
+    // due to the React render loop, calling `setEnvVar` twice in a row will
+    // cause it to not save the first set of data
+    const newEnvironment = Helpers.getEnvForWorkspace(workspace);
+    const newEnv = { ...(newEnvironment || {}), [key]: value };
 
     Storage.set({
       key: `${workspace.id}-env`,


### PR DESCRIPTION
If setEnvVar was used twice in a row, the first env var key/value pairs
would be dropped and the second would be kept. This was due to us
pulling `environment` from React's state and the re-render cycle
doesn't occur quick enough for `environment` to have changes from
update 1 of 2.

By pulling directly from localStorage, which is synchronous, it
guarantees the updates took effect