### PR TITLE
Bugfix: New Routes Show Zero In Response Section

### DIFF
--- a/src/route/ApiError.tsx
+++ b/src/route/ApiError.tsx
@@ -38,15 +38,19 @@ export default function ApiError({ route }: { route: Route }) {
 
   const isJSON = error.response.data && isObject(error.response.data);
 
+  const hasConfigHeaders = !!Object.keys(error?.config?.headers || {}).length;
+
   return (
     <div>
-      <div
-        style={{
-          color: responseColor,
-        }}
-      >
-        {error.response.status}
-      </div>
+      {error?.response?.status ? (
+        <div
+          style={{
+            color: responseColor,
+          }}
+        >
+          {error.response.status}
+        </div>
+      ) : null}
 
       {error.response.data && isJSON && (
         <ReactJson
@@ -68,7 +72,7 @@ export default function ApiError({ route }: { route: Route }) {
         </div>
       )}
 
-      <Headers headers={error.config.headers} />
+      {hasConfigHeaders ? <Headers headers={error.config.headers} /> : null}
     </div>
   );
 }

--- a/src/route/ApiResponse.tsx
+++ b/src/route/ApiResponse.tsx
@@ -34,19 +34,20 @@ export default function ApiResponse({ route }: { route: Route }) {
 
   const isJSON = response.data && isObject(response.data);
 
+  const hasResponseHeaders = !!Object.keys(response?.headers || {}).length;
+
   return (
     <div>
-      {response && response.status && (
+      {response?.status ? (
         <div
           className="flex-shrink-0 inline-flex text-xs font-bold bg-transparent border rounded py-1 px-2 mb-2"
           style={{
-            ...Helpers.getStyles(darkMode, "responseStatusCode"),
             color: responseColor,
           }}
         >
           {response.status}
         </div>
-      )}
+      ) : null}
 
       {response.data && isJSON && (
         <ReactJson
@@ -68,7 +69,7 @@ export default function ApiResponse({ route }: { route: Route }) {
         </div>
       )}
 
-      <Headers headers={response.headers} />
+      {hasResponseHeaders ? <Headers headers={response.headers} /> : null}
     </div>
   );
 }


### PR DESCRIPTION
When a workspace is initialized and routes are loaded for the first
time, before requests are made to a route they would show `0` because
of a `status` that defaults to `0`. They would also show `Headers +`
but clicking on the div to expand and see headers would render an empty
box.

<img width="115" alt="Screen Shot 2020-10-25 at 1 55 27 PM" src="https://user-images.githubusercontent.com/246603/97120694-369cf300-16d6-11eb-8cbf-d99860bcddfd.png">
