### PR TITLE
Feature: Cleanup UI

### DIFF
--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -13,7 +13,7 @@ import { stringify } from "querystring";
 
 import Storage from "./storage";
 
-import { Route, Workspace, ParamType } from "../types";
+import { Route, Workspace, ParamType, GenericObject } from "../types";
 
 const Helpers = {
   initializeRoute(routeConfig: any, route: Route) {
@@ -115,8 +115,8 @@ const Helpers = {
   }: {
     route: any;
     baseUrl: string;
-    urlParams: Object;
-    qsParams?: Object;
+    urlParams: GenericObject;
+    qsParams?: GenericObject;
   }) {
     const stringifiedQS =
       qsParams && !!Object.keys(qsParams).length
@@ -209,7 +209,6 @@ const Helpers = {
             };
 
       case "routePanelHeader":
-      case "responseStatusCode":
         return darkMode
           ? { border: "1px solid rgb(56, 56, 56)" }
           : { border: "1px solid #eee" };
@@ -238,11 +237,14 @@ const Helpers = {
       active:
         "inline-block border-l border-t border-r rounded-t py-2 px-4 text-blue-700 font-semibold",
       inactive:
-        "inline-block py-2 px-4 text-blue-500 hover:text-blue-800 font-semibold",
+        "inline-block py-2 px-4 text-blue-600 hover:text-blue-800 font-semibold",
       disabled:
         "inline-block py-2 px-4 text-gray-400 font-semibold cursor-not-allowed",
     },
   },
+
+  reactJsonViewTheme: (darkMode: boolean) =>
+    darkMode ? "ocean" : "rjv-default",
 };
 
 export default Helpers;

--- a/src/route/ApiError.tsx
+++ b/src/route/ApiError.tsx
@@ -54,7 +54,7 @@ export default function ApiError({ route }: { route: Route }) {
           displayObjectSize={false}
           displayDataTypes={false}
           src={error.response.data}
-          theme={context.darkMode ? "bright" : "rjv-default"}
+          theme={Helpers.reactJsonViewTheme(context.darkMode)}
         />
       )}
 

--- a/src/route/ApiResponse.tsx
+++ b/src/route/ApiResponse.tsx
@@ -38,9 +38,12 @@ export default function ApiResponse({ route }: { route: Route }) {
     <div>
       {response && response.status && (
         <div
-          className="flex-shrink-0 inline-flex text-xs font-bold bg-transparent border rounded py-1 px-2 mb-2"
+          className={`flex-shrink-0 inline-flex text-xs font-bold border rounded py-1 px-2 mb-1 ${
+            darkMode
+              ? "bg-gray-800 border-gray-900"
+              : "bg-gray-200 border-gray-400"
+          }`}
           style={{
-            ...Helpers.getStyles(darkMode, "responseStatusCode"),
             color: responseColor,
           }}
         >
@@ -54,7 +57,7 @@ export default function ApiResponse({ route }: { route: Route }) {
           displayObjectSize={false}
           displayDataTypes={false}
           src={response.data}
-          theme={darkMode ? "bright" : "rjv-default"}
+          theme={Helpers.reactJsonViewTheme(darkMode)}
         />
       )}
 

--- a/src/route/BodyPreview.tsx
+++ b/src/route/BodyPreview.tsx
@@ -22,7 +22,7 @@ export default function BodyPreview({ route }: BodyPreviewProps) {
   return (
     <div className="mb-4">
       <div
-        className="flex-shrink-0 inline-flex text-xs font-bold bg-transparent mb-2"
+        className="flex-shrink-0 inline-flex text-xs font-bold bg-transparent mb-1"
         style={{
           ...Helpers.getStyles(darkMode, "label"),
         }}
@@ -34,7 +34,7 @@ export default function BodyPreview({ route }: BodyPreviewProps) {
         displayObjectSize={false}
         displayDataTypes={false}
         src={{ ...body }}
-        theme={darkMode ? "bright" : "rjv-default"}
+        theme={Helpers.reactJsonViewTheme(darkMode)}
       />
     </div>
   );

--- a/src/route/Headers.tsx
+++ b/src/route/Headers.tsx
@@ -12,7 +12,7 @@ export default function Headers({ headers }: { headers: any }) {
   }
 
   return (
-    <div style={{ marginTop: "4px" }}>
+    <div className="mt-2">
       <div
         onClick={() => setCollapsed(!collapsed)}
         style={{ cursor: "pointer" }}
@@ -21,13 +21,13 @@ export default function Headers({ headers }: { headers: any }) {
       </div>
       {!collapsed && (
         <div
-          className={darkMode ? "text-gray-100" : "text-gray-800"}
+          className={`${
+            darkMode
+              ? "text-gray-100 border-gray-700"
+              : "text-gray-800 border-gray-300"
+          } rounded text-xs p-2 border`}
           style={{
-            padding: "8px",
-            border: "1px solid #eee",
-            fontSize: "10px",
             overflowX: "scroll",
-            maxWidth: "400px",
           }}
         >
           {map(headers, (value, name) => {

--- a/src/route/Navigation.tsx
+++ b/src/route/Navigation.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { useContext } from "react";
+
+import Context from "../Context";
 
 import Helpers from "../lib/helpers";
 
@@ -14,16 +16,22 @@ type Props = {
 };
 
 export default ({ tabs, activeTab, setActiveTab }: Props) => {
+  const { darkMode } = useContext(Context);
+
   const renderTabs = (
     tab: Tab,
     activeTab: string,
     setActiveTab: (key: string) => void
   ) => {
-    let anchorClasses = Helpers.classes.tabs.inactive;
+    let anchorClasses = `${Helpers.classes.tabs.inactive} ${
+      darkMode ? "border-gray-700" : ""
+    }`;
     let liClasses = "mr -1";
 
     if (tab.key === activeTab) {
-      anchorClasses = Helpers.classes.tabs.active;
+      anchorClasses = `${Helpers.classes.tabs.active} ${
+        darkMode ? "border-gray-700" : ""
+      }`;
       liClasses = "-mb-px mr-1";
     }
 
@@ -44,7 +52,7 @@ export default ({ tabs, activeTab, setActiveTab }: Props) => {
   };
 
   return (
-    <ul className="flex border-b">
+    <ul className={`flex border-b ${darkMode ? "border-gray-700" : ""}`}>
       {tabs.map((tab) => renderTabs(tab, activeTab, setActiveTab))}
     </ul>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+export interface GenericObject {
+  [key: string]: any;
+}
+
 export type Option = {
   label?: string;
   value: any;


### PR DESCRIPTION
- React-Json-View now uses a DarkMode theme that isn't a fully black
background
- Update a few files where we had custom styles to be more in-line by
utilizing Tailwind classes.

**Sample Screenshot:**
<img width="1144" alt="Screen Shot 2020-10-25 at 1 48 44 PM" src="https://user-images.githubusercontent.com/246603/97120880-a495ea00-16d7-11eb-8232-2e870c60c641.png">
