### PR TITLE
TECH: Add "deprecated" Tag to Route Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,26 @@ const superheroes = {
 };
 ```
 
+## Route Deprecation
+- Each route can specify its deprecation status by adding a `deprecation` key to the object.
+- `deprecation` accepts a boolean and will by default is set to `false`
+
+Usage:
+
+```javascript
+const superheroes = {
+  id: "superheroes",
+  name: "Superheroes",
+  routes: [
+    {
+      name: "Fetch Superhero",
+      path: "/v1/superheroes/:superhero_id",
+      deprecated: true
+    },
+  ],
+};
+```
+
 ## Questions
 
 > Why did you name this `badmagic`?

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ const superheroes = {
 ```
 
 ## Route Deprecation
-- Each route can specify its deprecation status by adding a `deprecation` key to the object.
-- `deprecation` accepts a boolean and will by default is set to `false`
+- Each route can specify its deprecation status by adding a `deprecated` key to the object.
+- `deprecated` accepts a boolean and will by default is set to `false`
 
 Usage:
 

--- a/example/src/dog-workspace.ts
+++ b/example/src/dog-workspace.ts
@@ -166,5 +166,16 @@ export const dogWorkspace = {
       },
       tags: ["dogs"],
     },
+
+    {
+      name: "Breeds (old)",
+      path: "/breeds/list/all",
+      responses: {
+        "200": {
+          description: "successful operation",
+        },
+      },
+      deprecated: true
+    },
   ],
 };

--- a/src/Route.tsx
+++ b/src/Route.tsx
@@ -146,12 +146,7 @@ export default function Route({ route }: { route: Route }) {
 
         {isDeprecated && 
         <div
-        className={`flex flex-shrink-0 items-center justify-center text-xs text-gray-700 font-semibold p-1 mr-2 border rounded ${
-          darkMode ? "border-gray-700" : "border-gray-300"
-        }`}
-        style={{
-          backgroundColor: "red",
-        }}
+        className={`flex flex-shrink-0 items-center justify-center text-xs text-white font-semibold p-1 mr-2 bg-red-700 rounded`}
       >
         DEPRECATED
       </div>

--- a/src/Route.tsx
+++ b/src/Route.tsx
@@ -85,6 +85,8 @@ export default function Route({ route }: { route: Route }) {
       : null,
   ]);
 
+  const isDeprecated = route.deprecated || false
+
   const renderBody = (activeTab: string) => {
     let content;
 
@@ -141,6 +143,19 @@ export default function Route({ route }: { route: Route }) {
         >
           {method.toUpperCase()}
         </div>
+
+        {isDeprecated && 
+        <div
+        className={`flex flex-shrink-0 items-center justify-center text-xs text-gray-700 font-semibold p-1 mr-2 border rounded ${
+          darkMode ? "border-gray-700" : "border-gray-300"
+        }`}
+        style={{
+          backgroundColor: "red",
+        }}
+      >
+        DEPRECATED
+      </div>
+        }
 
         <div
           className={`flex flex-grow-2 mr-auto ${


### PR DESCRIPTION
Adding a means of showing an endpoint is deprecated

![image](https://user-images.githubusercontent.com/1951558/114051465-f7a4c900-9841-11eb-955a-38c744d7c17a.png)

Steps to reproduce:
- Each route can specify its deprecation status by adding a `deprecation` key to the object.
- `deprecation` accepts a boolean and will by default is set to `false`
