### PR TITLE
perf: selectively collapse items in api responses

### DIFF
--- a/src/route/ApiResponse.tsx
+++ b/src/route/ApiResponse.tsx
@@ -60,6 +60,28 @@ export default function ApiResponse({ route }: { route: Route }) {
           displayDataTypes={false}
           src={response.data}
           theme={Helpers.reactJsonViewTheme(darkMode)}
+          shouldCollapse={({ type, src, namespace, name }) => {
+            // collapse anything more than 3 levels deep
+            if (namespace.length > 3) {
+              return true;
+            }
+
+            // collapse all but the first 5 elements of arrays
+            if (Number(name) > 4) {
+              return true;
+            }
+
+            // collapse arrays with more than 50 elements
+            if (type === "array" && Array.isArray(src) && src.length > 50) {
+              return true;
+            }
+
+            if (type === "object" && Object.keys(src).length > 50) {
+              return true;
+            }
+
+            return false;
+          }}
         />
       )}
 


### PR DESCRIPTION
When an API response is very large, rendering the full response is very expensive. Even mousing over the JSON view can lock the browser thread for several seconds. This will collapse the following in the response on initial render:

1. More than 3 levels deep (so `records.data[0]` won't be collapsed, but `records.data[0].objectOrArray` will be)
2. All but the first 5 elements of any array (so `records.data[4]` will not be collapsed, but `records.data[5]` will be)
3. All arrays with more than 50 elements
4. All objects with more than 50 properties