### PR TITLE
Add CI checks using GitHub Actions - typechecking and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
 
       - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Automated Type and Format Checking
+
+on: [push]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --no-progress --non-interactive
+
+      - name: Format Check
+        run: yarn format-check
+
+      - name: Type Check
+        run: yarn typecheck

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublish": "npm run build",
+    "format-check": "prettier -l 'src/**/*.{ts,tsx,js,json,md}'",
+    "prettier": "prettier --write 'src/**/*.{ts,tsx,js,json,md}'",
     "typecheck": "tsc --noEmit",
     "copy-css": "mkdir -p dist/css && cp ./src/css/*.min.css ./dist/css/"
   },


### PR DESCRIPTION
This adds GitHub Actions for checking Typescript (`yarn tsc --noEmit`) and Prettier (`yarn format-check`)– we'll need to update the GitHub protected branch settings once this merges as well.