### PR TITLE
Add Custom Body / QS Params

### DIFF
--- a/src/common/AddButton.tsx
+++ b/src/common/AddButton.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function AddButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      className="bg-blue-500 hover:bg-blue-700 text-white text-xs rounded-full ml-1 h-5 w-5 items-center justify-center flex self-center flex-shrink-0"
+      onClick={onClick}
+    >
+      +
+    </button>
+  );
+}

--- a/src/common/Input.tsx
+++ b/src/common/Input.tsx
@@ -21,10 +21,10 @@ export default function Input({
   type?: string;
   required?: boolean;
   onChange: (value: any) => void;
-  onSubmit: () => void;
+  onSubmit?: () => void;
 }) {
   const onKeyDown = (e: any) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && onSubmit) {
       onSubmit();
     }
   };

--- a/src/common/InputContainer.tsx
+++ b/src/common/InputContainer.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export function InputContainer({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`flex flex-grow ${className ? className : ""}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/common/InputContainer.tsx
+++ b/src/common/InputContainer.tsx
@@ -3,10 +3,7 @@ import React from "react";
 export function InputContainer({
   children,
   className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+}: PropsWithChildren<{className?: string}>) {
   return (
     <div className={`flex flex-grow ${className ? className : ""}`}>
       {children}

--- a/src/common/InputContainer.tsx
+++ b/src/common/InputContainer.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { PropsWithChildren } from "react";
 
 export function InputContainer({
   children,
   className,
-}: PropsWithChildren<{className?: string}>) {
+}: PropsWithChildren<{ className?: string }>) {
   return (
     <div className={`flex flex-grow ${className ? className : ""}`}>
       {children}

--- a/src/common/InputLabelContainer.tsx
+++ b/src/common/InputLabelContainer.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import Label from "./Label";
+import Required from "./Required";
+
+import { Size } from "../types";
+
+export function InputLabelContainer({
+  label,
+  children,
+  required,
+  size,
+  marginBottomClass,
+}: {
+  label: string;
+  children?: React.ReactNode;
+  required?: boolean;
+  size: Size;
+  marginBottomClass?: string;
+}) {
+  return (
+    <div className="flex items-center">
+      <Label size={size || "lg"} marginBottomClass={marginBottomClass}>
+        {label} {required && <Required />}
+      </Label>
+      {children}
+    </div>
+  );
+}

--- a/src/common/route/AddCustomParam.tsx
+++ b/src/common/route/AddCustomParam.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useCallback, useEffect } from "react";
+
+import Input from "../Input";
+import { AddButton } from "../AddButton";
+import Button from "../Button";
+import { InputContainer } from "../InputContainer";
+import { InputLabelContainer } from "../InputLabelContainer";
+
+import { Param, ParamType } from "../../types";
+
+export function AddCustomParam({
+  customParams,
+  setCustomParams,
+  paramType,
+}: {
+  customParams: Param[];
+  setCustomParams: (params: Param[]) => void;
+  paramType: ParamType;
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [param, setParam] = useState<null | Param>(null);
+
+  let supportedInputTypes = [{ label: "Text", value: "text" }];
+
+  if (paramType === "body") {
+    supportedInputTypes = [
+      ...supportedInputTypes,
+      ...[
+        { label: "Date", value: "date" },
+        { label: "Datetime", value: "datetime" },
+        { label: "Number", value: "number" },
+        { label: "JSON", value: "json" },
+      ],
+    ];
+  }
+
+  useEffect(() => {
+    // Rather than making the use select "Text" from a single-option dropdown menu, default to that
+    if (paramType === "qsParams") {
+      setParam({ name: "", type: "text" });
+    }
+  }, [paramType]);
+
+  const onSubmit = useCallback(() => {
+    if (param) {
+      setCustomParams([...customParams, param]);
+      // Same as above, don't reset the type for `qsParams` because that will require use to select `type: text`
+      // from the dropdown
+      setParam(paramType === "qsParams" ? { name: "", type: "text" } : null);
+      setIsVisible(false);
+    }
+  }, [customParams, param, paramType]);
+
+  if (!isVisible) {
+    return (
+      <InputLabelContainer
+        label="Add Custom Param"
+        size="xs"
+        marginBottomClass="mb-0"
+      >
+        <AddButton onClick={() => setIsVisible(true)} />
+      </InputLabelContainer>
+    );
+  } else if (!param) {
+    return (
+      <>
+        <InputLabelContainer label="Select Param Type" size="xs" />
+        <Input
+          options={supportedInputTypes}
+          value=""
+          label="Select Param Type"
+          onChange={(type: string) => {
+            let newParam: Param = { name: "" };
+            if (type == "datetime") {
+              // Using this placeholder will trigger the `Now` assist button to popup
+              newParam.placeholder = new Date().toISOString();
+            } else if (type == "json") {
+              newParam.type = "textarea";
+              newParam.defaultValue = `{"key": "value"}`;
+              newParam.json = true;
+            } else if (["text", "number", "date"].includes(type)) {
+              newParam.type = type;
+            }
+            setParam(newParam);
+          }}
+        />
+      </>
+    );
+  }
+
+  return (
+    <InputContainer className="items-end">
+      <div>
+        <InputLabelContainer label="Param Name" size="xs" />
+        <Input
+          value={param.name}
+          label="Param Name"
+          placeholder="some_variable"
+          required={param.required}
+          onChange={(name: string) => setParam({ ...param, name })}
+          onSubmit={onSubmit}
+        />
+      </div>
+
+      <div>
+        <Button className="flex-grow-0 ml-1" onClick={onSubmit}>
+          Add
+        </Button>
+      </div>
+    </InputContainer>
+  );
+}


### PR DESCRIPTION
Fixes https://github.com/smartrent/badmagic/issues/78 and https://github.com/smartrent/badmagic/issues/13

## QS Params

<img width="277" alt="Screen Shot 2022-10-16 at 12 59 32 PM" src="https://user-images.githubusercontent.com/246603/196055981-a3776f59-478e-4ec6-8f86-90b1c96334b6.png">
<img width="524" alt="Screen Shot 2022-10-16 at 12 59 47 PM" src="https://user-images.githubusercontent.com/246603/196055982-2609d24d-f49d-4aeb-9a45-c86382c5c00d.png">
<img width="180" alt="Screen Shot 2022-10-16 at 12 59 42 PM" src="https://user-images.githubusercontent.com/246603/196055985-d3ca937d-2635-47a6-b21f-d7dbb1fe2f6e.png">

## Body Params

A few supported input types out of the gate (JSON type could use some love, but we can handle that iteratively)

<img width="487" alt="Screen Shot 2022-10-16 at 12 59 54 PM" src="https://user-images.githubusercontent.com/246603/196055993-5f02b702-4bb9-4c6b-98c0-1d251b8ec55b.png">
