### PR TITLE
github actions-cache v1/2 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |


### PR DESCRIPTION
They are deprecating github actions-cache v1/2 and recommending upgrading to v4 as there are no breaking changes. But if it is not done older versions will cease to function on: February 1st, 2025.

REFS: 

* https://github.com/actions/cache/discussions/1510
* https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes